### PR TITLE
CI 対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode10
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+before_install:
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew reinstall qt ; fi
+
+before_script:
+  - git submodule update --init --recursive
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/release_macos.sh ; fi
+ 
+after_script:
+
+after_success:
+
+after_failure:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+os:
+  - Visual Studio 2017
+
+build:
+  verbosity: detailed
+
+configuration:
+  - Release
+
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+
+install:
+  - git submodule update --init --recursive
+  - Build\Depends\prepare.bat
+  - Build\Depends\allDownload.bat
+  - set CMAKE_URL="https://cmake.org/files/v3.12/cmake-3.12.3-win64-x64.zip"
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\projects\deps > nul
+  - move C:\projects\deps\cmake-* C:\projects\deps\cmake # Move to a version-agnostic directory
+  - set PATH=C:\projects\deps\cmake\bin;%PATH%
+  - cmake --version
+
+
+build_script:
+  - Scripts\release_win.bat
+
+artifacts:
+  - path: ./Tools/Ss6Converter.zip
+    name: Ss6Converter


### PR DESCRIPTION
# したこと
Pull Request の Ss6Converter をビルドし、ビルド成果物(artifacts)を保存するようにしました。

# 対応
- Windows(Appveyor)
- macOS(Travis CI)

# 未対応
- [ ] macOS の成果物の保存(Travis CI の成果物の保存は Amazon S3 が必要です。)
- [ ] Windows/macOS の Viewer のビルド
- [ ] Windows/macOS の Viewer2 のビルド